### PR TITLE
Fix documentation error with `group()` - fixes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Take a look at the example above.
 
 ### group(expanded:boolean = true)
 
-Begins a group. By default the group is expanded. Provide true if you want the group to be collapsed.
+Begins a group. By default the group is expanded. Provide false if you want the group to be collapsed.
 
 ```javascript
 console.message()

--- a/console.message.js
+++ b/console.message.js
@@ -50,7 +50,7 @@
 
   ConsoleMessage.prototype = {
     /**
-     * Begins a group. By default the group is expanded. Provide true if you want the group to be collapsed.
+     * Begins a group. By default the group is expanded. Provide false if you want the group to be collapsed.
      * @param {boolean} [expanded = true] -
      * @returns {ConsoleMessage} - Returns the message object itself to allow chaining.
      */


### PR DESCRIPTION
As discussed
