### PR TITLE
Have print() return a new ConsoleMessage instance

### DIFF
--- a/console.message.js
+++ b/console.message.js
@@ -207,10 +207,12 @@
      */
     print: function () {
       if (typeof console == 'undefined') {
-        return;
+        return new ConsoleMessage();
       }
 
       this._onReady(this._print);
+      
+      return new ConsoleMessage();
     },
 
     _print: function () {


### PR DESCRIPTION
Make `print()` seem like it's flushing.
